### PR TITLE
認証周りのバグ修正

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # THIS FILE WILL BE COMMITED TO GITHUB
 # DO NOT WRITE SENSITIVE DATA HERE
 # INSTEAD, CREATE AND EDIT .env.local
-APP_ID=dummy_app_id_of_lark_openapi
-APP_SECRET=dummy_app_secret
+VITE_APP_ID=dummy_app_id_of_lark_openapi
+VITE_APP_SECRET=dummy_app_secret

--- a/src/apis.ts
+++ b/src/apis.ts
@@ -62,12 +62,15 @@ async function fetchNewToken(): Promise<string> {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      app_id: import.meta.env.APP_ID,
-      app_secret: import.meta.env.APP_SECRET,
+      app_id: import.meta.env.VITE_APP_ID,
+      app_secret: import.meta.env.VITE_APP_SECRET,
     }),
   });
 
   const newToken = response.tenant_access_token;
+  if (!newToken) {
+    throw new Error("Failed to fetch new token");
+  }
   localStorage.setItem(TOKEN_KEY, newToken);
   localStorage.setItem(TOKEN_TIMESTAMP_KEY, Date.now().toString());
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite/types/importMeta.d.ts" />


### PR DESCRIPTION
`VITE_`を頭につけなければ値を利用できないような仕様であったので、そのようにした

また、エラーハンドリングを適切に行い、トークンを取得できない場合に、ローカルストレージに書き込む等の処理をしないようにした
(どうもtenant access tokenを取得するAPIは失敗しても200を返すようだ)
